### PR TITLE
Fix/package name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 SET(CMAKE_CXX_STANDARD 11)
 SET(CMAKE_CXX_STANDARD_REQUIRED ON)
-project(teraranger_hub)
+project(teraranger_array)
 
 find_package(catkin REQUIRED COMPONENTS
   message_generation

--- a/README.md
+++ b/README.md
@@ -9,9 +9,21 @@ This package is a collection of nodes for TeraRanger array solutions:
 
 To clone and build the package in your workspace follow these steps:
 
+* If you have ssh key setup for your github account:
+
 ```
 cd ~/ros_ws/src
-git clone git@github.com:Terabee/teraranger_hub.git
+git clone git@github.com:Terabee/teraranger_array.git
+cd ~/ros_ws
+catkin_make
+source devel/setup.bash
+```
+
+* If you prefer to use https use this set of commands:
+
+```
+cd ~/ros_ws/src
+git clone https://github.com/Terabee/teraranger_array.git
 cd ~/ros_ws
 catkin_make
 source devel/setup.bash
@@ -23,7 +35,7 @@ TeraRanger Tower and TeraRanger Hub utilize **TeraRanger One** sensors for the d
 
 After your workspace is built and sourced:
 ```
-rosrun teraranger_hub teraranger_one _portname:=/dev/ttyACM0
+rosrun teraranger_array teraranger_one _portname:=/dev/ttyACM0
 ```
 
 ## Running TeraRanger Multiflex
@@ -31,7 +43,7 @@ rosrun teraranger_hub teraranger_one _portname:=/dev/ttyACM0
 To use TeraRanger Multiflex please execute the following command after building and sourcing your workspace:
 
 ```
-rosrun teraranger_hub teraranger_multiflex _portname:=/dev/ttyACM0
+rosrun teraranger_array teraranger_multiflex _portname:=/dev/ttyACM0
 ``` 
 
 ## Changing Sensor Configuration

--- a/include/teraranger_array/helper_lib.h
+++ b/include/teraranger_array/helper_lib.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-namespace teraranger_hub
+namespace teraranger_array
 {
 static const uint8_t crc_table[] = {0x00, 0x07, 0x0e, 0x09, 0x1c, 0x1b, 0x12, 0x15, 0x38, 0x3f, 0x36, 0x31, 0x24, 0x23,
                                     0x2a, 0x2d, 0x70, 0x77, 0x7e, 0x79, 0x6c, 0x6b, 0x62, 0x65, 0x48, 0x4f, 0x46, 0x41,
@@ -31,6 +31,6 @@ class HelperLib
         static uint8_t crc8(uint8_t *p, uint8_t len);
         static float two_chars_to_float(uint8_t c1, uint8_t c2);
 };
-} // namespace teraranger_hub
+} // namespace teraranger_array
 
 #endif // TERARANGER_HELPER_LIB_H

--- a/include/teraranger_array/serial_port.h
+++ b/include/teraranger_array/serial_port.h
@@ -16,7 +16,7 @@
 
 #define SERIAL_POLL_RATE 30000
 
-namespace teraranger_hub
+namespace teraranger_array
 {
 
 class SerialPort
@@ -40,6 +40,6 @@ public:
   boost::function<void(uint8_t)> *serial_callback_function;
 };
 
-} // namespace teraranger_hub
+} // namespace teraranger_array
 
 #endif // TERARANGER_HUB_SERIAL_PORT_H

--- a/include/teraranger_array/teraranger_evo.h
+++ b/include/teraranger_array/teraranger_evo.h
@@ -8,8 +8,8 @@
 
 #include "serial_port.h"
 #include <dynamic_reconfigure/server.h>
-#include <teraranger_hub/TerarangerHubEvoConfig.h>
-#include <teraranger_hub/RangeArray.h>
+#include <teraranger_array/TerarangerHubEvoConfig.h>
+#include <teraranger_array/RangeArray.h>
 
 #define BUFFER_SIZE 31
 #define RANGES_FRAME_LENGTH 20
@@ -18,7 +18,7 @@
 #define IMU_EULER_FRAME_LENGHT 10
 #define IMU_QUATLIN_FRAME_LENGHT 18
 
-namespace teraranger_hub
+namespace teraranger_array
 {
 // Protocol commands
 static const char ENABLE_CMD[5] = {(char)0x00, (char)0x52, (char)0x02, (char)0x01, (char)0xDF};
@@ -79,9 +79,9 @@ private:
   int number_of_sensor;
   std::string frame_id;
 
-  teraranger_hub::RangeArray measure;
+  teraranger_array::RangeArray measure;
 };
 
-} // namespace teraranger_hub
+} // namespace teraranger_array
 
 #endif  // TERARANGER_EVO_H

--- a/include/teraranger_array/teraranger_multiflex.h
+++ b/include/teraranger_array/teraranger_multiflex.h
@@ -6,11 +6,11 @@
 #include <string>
 #include "serial_port.h"
 #include <dynamic_reconfigure/server.h>
-#include <teraranger_hub/TerarangerHubMultiflexConfig.h>
+#include <teraranger_array/TerarangerHubMultiflexConfig.h>
 
 #define BUFFER_SIZE 20
 
-namespace teraranger_hub
+namespace teraranger_array
 {
 
 // TODO: Re-enable if multiple modes are supported by Multiflex
@@ -67,6 +67,6 @@ public:
   std::string ns_;
 };
 
-} // namespace teraranger_hub
+} // namespace teraranger_array
 
 #endif // TERARANGER_HUB_MULTIFLEX_H_

--- a/include/teraranger_array/teraranger_one.h
+++ b/include/teraranger_array/teraranger_one.h
@@ -7,12 +7,12 @@
 
 #include "serial_port.h"
 #include <dynamic_reconfigure/server.h>
-#include <teraranger_hub/TerarangerHubOneConfig.h>
-#include <teraranger_hub/RangeArray.h>
+#include <teraranger_array/TerarangerHubOneConfig.h>
+#include <teraranger_array/RangeArray.h>
 
 #define BUFFER_SIZE 19
 
-namespace teraranger_hub
+namespace teraranger_array
 {
 
 static const char PRECISE_MODE[] = "PPP";
@@ -55,9 +55,9 @@ private:
   const uint8_t number_of_sensors = 8;
   const std::string frame_id = "base_range_";
 
-  teraranger_hub::RangeArray measure;
+  teraranger_array::RangeArray measure;
 };
 
-} // namespace teraranger_hub
+} // namespace teraranger_array
 
 #endif // TERARANGER_HUB_ONE_H

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <package>
   <name>teraranger_array</name>
   <version>1.0.0</version>
-  <description>The teraranger_array package</description>
+  <description>The teraranger_array package for TeraRanger Array Products (Multiflex, One, Evo)</description>
 
   <maintainer email="pierre-louis.kabaradjian@terabee.com">Pierre-Louis Kabaradjian</maintainer>
   <maintainer email="krzysztof.zurad@terabee.com">Krzysztof Zurad</maintainer>
@@ -13,7 +13,7 @@
   <license>GPL</license>
 
   <url type="website">http://wiki.ros.org/tr_hub_parser</url>
-  <url type="website">https://github.com/Terabee/tr_hub_parser</url>
+  <url type="website">https://github.com/Terabee/teraranger_array</url>
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>message_generation</build_depend>

--- a/package.xml
+++ b/package.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <package>
-  <name>teraranger_hub</name>
+  <name>teraranger_array</name>
   <version>1.0.0</version>
-  <description>The teraranger_hub package</description>
+  <description>The teraranger_array package</description>
 
   <maintainer email="pierre-louis.kabaradjian@terabee.com">Pierre-Louis Kabaradjian</maintainer>
   <maintainer email="krzysztof.zurad@terabee.com">Krzysztof Zurad</maintainer>

--- a/src/helper_lib.cpp
+++ b/src/helper_lib.cpp
@@ -1,6 +1,6 @@
-#include <teraranger_hub/helper_lib.h>
+#include <teraranger_array/helper_lib.h>
 
-namespace teraranger_hub
+namespace teraranger_array
 {
     uint8_t HelperLib::crc8(uint8_t *p, uint8_t len)
     {
@@ -23,4 +23,4 @@ namespace teraranger_hub
         float res = (float)current_range;
         return res;
     }
-} //namespace teraranger_hub
+} //namespace teraranger_array

--- a/src/serial_port.cpp
+++ b/src/serial_port.cpp
@@ -2,9 +2,9 @@
 #include <ros/console.h>
 #include <ros/ros.h>
 
-#include <teraranger_hub/serial_port.h>
+#include <teraranger_array/serial_port.h>
 
-namespace teraranger_hub
+namespace teraranger_array
 {
 
 SerialPort::SerialPort() : serial_callback_function()
@@ -94,4 +94,4 @@ void SerialPort::serialThread()
   return;
 }
 
-} // teraranger_hub
+} // teraranger_array

--- a/src/teraranger_evo.cpp
+++ b/src/teraranger_evo.cpp
@@ -1,11 +1,11 @@
 #include <ros/console.h>
 #include <string>
 
-#include <teraranger_hub/RangeArray.h>
-#include <teraranger_hub/teraranger_evo.h>
-#include <teraranger_hub/helper_lib.h>
+#include <teraranger_array/RangeArray.h>
+#include <teraranger_array/teraranger_evo.h>
+#include <teraranger_array/helper_lib.h>
 
-namespace teraranger_hub
+namespace teraranger_array
 {
 
 TerarangerHubEvo::TerarangerHubEvo()
@@ -19,7 +19,7 @@ TerarangerHubEvo::TerarangerHubEvo()
     ROS_INFO("node namespace: [%s]", ns_.c_str());
 
     // Publishers
-    range_publisher_ = nh_.advertise<teraranger_hub::RangeArray>("teraranger_evo", 8);
+    range_publisher_ = nh_.advertise<teraranger_array::RangeArray>("teraranger_evo", 8);
 
     // Serial Port init
     serial_port_ = new SerialPort();
@@ -208,7 +208,7 @@ TerarangerHubEvo::TerarangerHubEvo()
 
 int main(int argc, char **argv) {
   ros::init(argc, argv, "teraranger_hub_evo");
-  teraranger_hub::TerarangerHubEvo node;
+  teraranger_array::TerarangerHubEvo node;
   ros::spin();
 
   return 0;

--- a/src/teraranger_multiflex.cpp
+++ b/src/teraranger_multiflex.cpp
@@ -1,11 +1,11 @@
 #include <string>
 #include <sstream>
 #include <iomanip>
-#include <teraranger_hub/teraranger_multiflex.h>
-#include <teraranger_hub/helper_lib.h>
+#include <teraranger_array/teraranger_multiflex.h>
+#include <teraranger_array/helper_lib.h>
 #include <ros/console.h>
 
-namespace teraranger_hub
+namespace teraranger_array
 {
 
 TerarangerHubMultiflex::TerarangerHubMultiflex()
@@ -282,7 +282,7 @@ std::string TerarangerHubMultiflex::IntToString(int number)
 int main(int argc, char **argv)
 {
 	ros::init(argc, argv, "teraranger_hub_multiflex");
-	teraranger_hub::TerarangerHubMultiflex multiflex;
+	teraranger_array::TerarangerHubMultiflex multiflex;
 	ros::spin();
 
 	return 0;

--- a/src/teraranger_one.cpp
+++ b/src/teraranger_one.cpp
@@ -1,11 +1,11 @@
 #include <ros/console.h>
 #include <string>
-#include <teraranger_hub/RangeArray.h>
-#include <teraranger_hub/teraranger_one.h>
-#include <teraranger_hub/helper_lib.h>
+#include <teraranger_array/RangeArray.h>
+#include <teraranger_array/teraranger_one.h>
+#include <teraranger_array/helper_lib.h>
 
 
-namespace teraranger_hub
+namespace teraranger_array
 {
 
 TerarangerHubOne::TerarangerHubOne()
@@ -19,7 +19,7 @@ TerarangerHubOne::TerarangerHubOne()
   ROS_INFO("node namespace: [%s]", ns_.c_str());
 
   // Publishers
-  range_publisher_ = nh_.advertise<teraranger_hub::RangeArray>("teraranger_hub_one", 8);
+  range_publisher_ = nh_.advertise<teraranger_array::RangeArray>("teraranger_hub_one", 8);
 
   // Create serial port
   serial_port_ = new SerialPort();
@@ -183,7 +183,7 @@ void TerarangerHubOne::dynParamCallback(
 int main(int argc, char **argv)
 {
   ros::init(argc, argv, "teraranger_hub_one");
-  teraranger_hub::TerarangerHubOne teraranger_one;
+  teraranger_array::TerarangerHubOne teraranger_one;
   ros::spin();
 
   return 0;

--- a/test/test_teraranger_one.cpp
+++ b/test/test_teraranger_one.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
-#include <teraranger_hub/teraranger_one.h>
-#include <teraranger_hub/helper_lib.h>
+#include <teraranger_array/teraranger_one.h>
+#include <teraranger_array/helper_lib.h>
 
 class HubParserTest : public ::testing::Test{
 protected:
@@ -8,12 +8,12 @@ protected:
 };
 
 TEST_F(HubParserTest, crc8Test){
-  int16_t crc = teraranger_hub::HelperLib::crc8(input_buffer, 18);
+  int16_t crc = teraranger_array::HelperLib::crc8(input_buffer, 18);
   EXPECT_EQ(crc, input_buffer[18]);
 }
 
 TEST_F(HubParserTest, parsingTest){
-  float result = teraranger_hub::HelperLib::two_chars_to_float(input_buffer[2],input_buffer[3]);
+  float result = teraranger_array::HelperLib::two_chars_to_float(input_buffer[2],input_buffer[3]);
   ASSERT_FLOAT_EQ(result, 2215);
 }
 


### PR DESCRIPTION
This pull request changes the package name from teraranger_hub to teraranger_array. The reason for this change is because teraranger_hub is a product name, while teraranger_array can describe all our mult-sensor solutions.