### PR TITLE
Avoid narrowing cast in switch case

### DIFF
--- a/src/teraranger_evo.cpp
+++ b/src/teraranger_evo.cpp
@@ -424,7 +424,7 @@ void TerarangerHubEvo::dynParamCallback(
 {
   switch(level)
   {
-    case UINT32_MAX:// Catching first reconfigure call
+    case 0xffffffff:// Catching first reconfigure call
       reconfigure_output(config);
       reconfigure_rate(config);
       reconfigure_imu(config);

--- a/src/teraranger_evo.cpp
+++ b/src/teraranger_evo.cpp
@@ -424,7 +424,7 @@ void TerarangerHubEvo::dynParamCallback(
 {
   switch(level)
   {
-    case -1:// Catching first reconfigure call
+    case UINT32_MAX:// Catching first reconfigure call
       reconfigure_output(config);
       reconfigure_rate(config);
       reconfigure_imu(config);


### PR DESCRIPTION
`case -1` when the switch variable is uint32_t does not compile with C++11,
and is probably not a good idea anyway. As far as I can tell, casting -1
to unsigned gives the max unsigned value, so I replaced the -1 with UINT32_MAX.
That might be platform-dependent and I'm not even sure if it's defined
behaviour.

I'm building on ~kinetic~ melodic, which uses C++11 by default, hence the issue.