### PR TITLE
Make sure processAck always returns something

### DIFF
--- a/src/teraranger_evo.cpp
+++ b/src/teraranger_evo.cpp
@@ -162,8 +162,14 @@ bool TerarangerHubEvo::processAck(uint8_t* ack_buffer, const uint8_t* cmd)
         {
           return true;
         }
+        else if (ack_buffer[2] == NACK_VALUE)
+        {
+          ROS_ERROR("[%s] Command was not acknowledged", ros::this_node::getName().c_str());
+          return false;
+        }
         else
         {
+          ROS_ERROR("[%s] Invalid acknowledgment value", ros::this_node::getName().c_str());
           return false;
         }
       }

--- a/src/teraranger_evo.cpp
+++ b/src/teraranger_evo.cpp
@@ -162,7 +162,7 @@ bool TerarangerHubEvo::processAck(uint8_t* ack_buffer, const uint8_t* cmd)
         {
           return true;
         }
-        else if (ack_buffer[2] == NACK_VALUE)
+        else
         {
           return false;
         }


### PR DESCRIPTION
This is a compiler warning on my system, so we might as well fix it.

The change I made is just a suggestion, you might want to implement it differently, for instance by leaving the `else if` the way it was and adding an `else` that return false and logs a ros error.

Just for reference:

https://github.com/Terabee/teraranger_array/blob/25e74a158ce09716ae6d0e81b9947a9222548ab2/src/teraranger_evo.cpp#L151-L187