### PR TITLE
Move header to start of RangeArray.msg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+services:
+  - docker
+
+language: 
+  - cpp
+
+compiler:
+  - gcc
+
+notifications:
+  email:
+    on_success: always
+    on_failure: always
+    recipients:
+      - plk@terabee.com
+
+# configure the build environment(s)
+# https://github.com/ros-industrial/industrial_ci/blob/master/doc/index.rst#variables-you-can-configure
+env:
+  global: # global settings for all jobs
+    - ROS_REPO=ros
+  matrix: # each line is a job
+    - ROS_DISTRO="indigo"
+    - ROS_DISTRO="kinetic"
+    - ROS_DISTRO="melodic"
+
+# clone and run industrial_ci
+install:
+  - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .ci_config
+script:
+  - source .ci_config/travis.sh

--- a/msg/RangeArray.msg
+++ b/msg/RangeArray.msg
@@ -1,2 +1,2 @@
-sensor_msgs/Range[] ranges
 Header header
+sensor_msgs/Range[] ranges


### PR DESCRIPTION
The cpp tools require the header to be the first entry in the
message for ros::message_traits to recognize that the message
in fact has a header.  Moving the header fixes the issue reported
in https://github.com/Terabee/teraranger_array/issues/58, where 
ros::mesage_traits doesn't recognize the header which causes 
builds using e.g. message filters to fail.