### PR TITLE
Removed teraranger_array library from catkin_package LIBRARIES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ generate_messages(
 
 catkin_package(
   INCLUDE_DIRS include
-  LIBRARIES ${PROJECT_NAME}
+  #LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS roscpp sensor_msgs std_msgs message_runtime dynamic_reconfigure serial geometry_msgs
   DEPENDS Boost
 )


### PR DESCRIPTION
This file isn't built, so packages referencing teraranger_array
fail when searching for the non-existent library.  This fix
removes it from the list of dependent libraries in the
generated teraranger_arrayConfig.cmake.

Let me know if you want a corresponding issue to track against or if this 
is good enough as-is.  Thanks!